### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ maintenance = { status = "actively-developed" }
 default = []
 
 [dependencies]
-structopt = "0.2"
+structopt = "0.3"
 log = "0.4"
-simplelog = { version = "0.6", optional = true }
+simplelog = { version = "0.7", optional = true }
 
 [build-dependencies]
 skeptic = "0.13"

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,7 +85,7 @@ pub struct ConfigFileNoDef {
         long = "config",
         short = "c",
         parse(from_os_str),
-        raw(global = "true")
+        global = true
     )]
     filename: Option<PathBuf>,
 }

--- a/src/force.rs
+++ b/src/force.rs
@@ -31,7 +31,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug, Clone)]
 pub struct ForceFlag {
     /// Force the operation
-    #[structopt(name = "forceflag", long = "force", short = "f", raw(global = "true"))]
+    #[structopt(name = "forceflag", long = "force", short = "f", global = true)]
     pub force: bool,
 }
 

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -31,7 +31,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug, Clone)]
 pub struct HostV4Opt {
     /// Set the host IP (Ipv4 only)
-    #[structopt(name = "hostv4", long = "host", short = "-H", raw(global = "true"))]
+    #[structopt(name = "hostv4", long = "host", short = "-H", global = true)]
     host_addr: Option<Ipv4Addr>,
 }
 
@@ -104,7 +104,7 @@ pub struct HostV4Param {
 #[derive(StructOpt, Debug, Clone)]
 pub struct HostV6Opt {
     /// Set the host IP (Ipv6 only)
-    #[structopt(name = "hostv6", long = "host", short = "-H", raw(global = "true"))]
+    #[structopt(name = "hostv6", long = "host", short = "-H", global = true)]
     host_addr: Option<Ipv6Addr>,
 }
 
@@ -177,7 +177,7 @@ pub struct HostV6Param {
 #[derive(StructOpt, Debug, Clone)]
 pub struct HostOpt {
     /// Set the host IP (both IpV4 and IpV6 are supported)
-    #[structopt(name = "host", long = "host", short = "-H", raw(global = "true"))]
+    #[structopt(name = "host", long = "host", short = "-H", global = true)]
     host_addr: Option<IpAddr>,
 }
 

--- a/src/logopt.rs
+++ b/src/logopt.rs
@@ -41,7 +41,7 @@ pub struct LogLevelOpt {
         long = "log-level",
         short = "L",
         default_value = "info",
-        raw(global = "true")
+        global = true
     )]
     log_level: LevelFilter,
 }
@@ -92,7 +92,7 @@ pub struct LogLevelOptLower {
         long = "log-level",
         short = "l",
         default_value = "info",
-        raw(global = "true"),
+        global = true,
         conflicts_with = "loglevel"
     )]
     log_level: LevelFilter,
@@ -145,7 +145,7 @@ pub struct LogLevelNoDef {
         name = "loglevel",
         long = "log-level",
         short = "L",
-        raw(global = "true")
+        global = true
     )]
     log_level: Option<LevelFilter>,
 }
@@ -213,7 +213,7 @@ pub struct LogLevelNoDefLower {
         name = "loglevel",
         long = "log-level",
         short = "l",
-        raw(global = "true")
+        global = true
     )]
     log_level: Option<LevelFilter>,
 }

--- a/src/verbose.rs
+++ b/src/verbose.rs
@@ -42,7 +42,7 @@ pub struct Verbose {
         long = "verbose",
         short = "v",
         parse(from_occurrences),
-        raw(global = "true")
+        global = true
     )]
     verbosity_level: u8,
 }
@@ -101,7 +101,7 @@ pub struct VerboseNoDef {
         long = "verbose",
         short = "v",
         parse(from_occurrences),
-        raw(global = "true")
+        global = true
     )]
     verbosity_level: u8,
 }
@@ -177,7 +177,7 @@ pub struct QuietVerbose {
         short = "v",
         parse(from_occurrences),
         conflicts_with = "quietquiet",
-        raw(global = "true")
+        global = true
     )]
     verbosity_level: u8,
 
@@ -190,7 +190,7 @@ pub struct QuietVerbose {
         short = "q",
         parse(from_occurrences),
         conflicts_with = "quietverbose",
-        raw(global = "true")
+        global = true
     )]
     quiet_level: u8,
 }
@@ -261,7 +261,7 @@ pub struct SimpleVerbose {
         name = "simpleverbose",
         long = "verbose",
         short = "v",
-        raw(global = "true")
+        global = true
     )]
     pub verbose: bool,
 }


### PR DESCRIPTION
structopt v0.3 has get rid of the `raw` attribute.